### PR TITLE
 Update rest-client dependency to allow versions up to 2.1.x and increment version number

### DIFF
--- a/lib/synapse_client/version.rb
+++ b/lib/synapse_client/version.rb
@@ -1,3 +1,3 @@
 module SynapseClient
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/synapse_client.gemspec
+++ b/synapse_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rest-client', '~> 1.7', '>= 1.7.2'
+  spec.add_runtime_dependency 'rest-client', '>= 1.7.2', '< 2.2'
   spec.add_runtime_dependency 'map'
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
rest-client 2.1.0 is out with important fixes and is compatible.